### PR TITLE
Average out fan speed adjustments over the last n intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ To get the value  for the `--pwm`,  `--pwm-start-value` and `--pwm-stop-value` p
 * Use the `-t` or `--test` parameter, which will run some tests and detect the values at which the fans start and stop. However you need to have previously identified the PWM file (the `--pwm` parameter)
 * use the [pwmconfig tool](http://www.lm-sensors.org/wiki/man/pwmconfig).
 
+### Smooth fan speed adjustment
+
+Setting `--average` to a value > 1 prevents rapidly changing fan speeds. Target fan speed is then averaged over the last few intervals. 
+Combining this option with a very narrow temperature window (e.g. 3 degrees), a minimum fan speed of zero and sufficiently powerful fans will essentially keep the drives at a near constant temperature. 
+
 ### Drive auto spin down
 
 SATA drives can be configured to automatically spin down after a certain period of inactivity, which saves power. If your drives are configured to do so, you may notice that they do not spin down when HDD Fan control is running.

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -731,7 +731,7 @@ def set_high_priority(logger):
 
 
 def main(drive_filepaths, cpu_probe_filepath, fan_pwm_filepaths, fan_start_values, fan_stop_values, min_fan_speed_prct,
-         min_drive_temp, max_drive_temp, cpu_temp_range, interval_s, spin_down_time_s, hddtemp_daemon_port,
+         min_drive_temp, max_drive_temp, cpu_temp_range, avg_count, interval_s, spin_down_time_s, hddtemp_daemon_port,
          use_smartctl):
   logger = logging.getLogger("Main")
   fans = []
@@ -901,6 +901,11 @@ def cl_main():
                           help="""Minimum percentage of full fan speed to set the fan to.
                                   Never set to 0 unless you have other fans to cool down your system,
                                   or a case specially designed for passive cooling.""")
+  arg_parser.add_argument("--average",
+                          type=int,
+                          default=1,
+                          dest="avg_count",
+                          help="Number of intervals to average the fan speed over.")
   arg_parser.add_argument("-i",
                           "--interval",
                           type=int,
@@ -980,7 +985,11 @@ def cl_main():
           "Please set a higher spin down time, or use hdparm's -S switch "
           "to set SATA spin down time." % (args.spin_down_time_s, args.interval_s))
     exit(os.EX_USAGE)
-
+      
+  if args.avg_count < 1:
+    print("Average must be at least 1!")
+    exit(os.EX_USAGE)
+    
   # setup logger
   logging_level = {"warning": logging.WARNING,
                    "normal": logging.INFO,
@@ -1046,6 +1055,7 @@ def cl_main():
            args.min_temp,
            args.max_temp,
            args.cpu_temp_range,
+           args.avg_count,
            args.interval_s,
            args.spin_down_time_s,
            args.hddtemp_daemon_port if args.hddtemp_daemon else None,

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -21,6 +21,7 @@ import shutil
 import signal
 import socket
 import stat
+import statistics
 import subprocess
 import sys
 import syslog
@@ -735,6 +736,8 @@ def main(drive_filepaths, cpu_probe_filepath, fan_pwm_filepaths, fan_start_value
          use_smartctl):
   logger = logging.getLogger("Main")
   fans = []
+  speed_history = []
+
   try:
     # change process priority
     set_high_priority(logger)
@@ -819,6 +822,17 @@ def main(drive_filepaths, cpu_probe_filepath, fan_pwm_filepaths, fan_start_value
       fan_speed_prct = int(min(fan_speed_prct, 100))
       # enforce min fan speed
       fan_speed_prct = max(fan_speed_prct, min_fan_speed_prct)
+
+      # Fill the history list with initial values
+      for i in range(len(speed_history), avg_count):
+        speed_history.append(fan_speed_prct)
+
+      # Remove the oldest speed and append the current one
+      speed_history.pop(0)
+      speed_history.append(fan_speed_prct)
+
+      # Calculate mean (average) speed
+      fan_speed_prct = statistics.mean(speed_history)
 
       # set fan speed if needed
       for i, fan in enumerate(fans):


### PR DESCRIPTION
As described in #22, this PR adds the option to average the fan speed over the last n intervals. The number of intervals can be configured via a new config option: `--average`. This new parameter defaults to 1 and therefore does not change the existing behavior.

Why would that be necessary?
- The server is located in my living room. Jumping fan speeds are way more audible and disruptive then smooth adjustments over time. 
- My hard drives should not run warmer in summer than in winter. In order to keep drives at a constant operating temperature, one would have to configure a very narrow interval of minimum and maximum temperature, e.g. 3 degrees. This will result in lots of jumps between 0, 50 and 100% fan speed. With this change, such jumps no longer happen and the drives stay at the same temperature, all year round, regardless of ambient temperature.

Another benefit is that there is no need to guess the ideal lower and upper temperature range anymore. Just setting min and max temp to -1/+1 of ones ideal target temperature is enough.


Tested for the last week with a interval of 30s / average of 10. Works great so far.