### PR TITLE
musl libc does not support sched_getscheduler

### DIFF
--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -978,7 +978,7 @@ def set_high_priority(logger: logging.Logger) -> None:
     try:
         current_sched = os.sched_getscheduler(0)
     except OSError as e:
-        if e.errno != errno.ENOSYS: 
+        if e.errno != errno.ENOSYS:
             raise
         logger.warning(f"sched_getscheduler is not supported on this system, leaving scheduler as is")
     else:

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -11,6 +11,7 @@ import argparse
 import collections
 import contextlib
 import enum
+import errno
 import itertools
 import logging
 import logging.handlers

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -980,7 +980,7 @@ def set_high_priority(logger: logging.Logger) -> None:
     except OSError as e:
         if e.errno != errno.ENOSYS:
             raise
-        logger.warning(f"sched_getscheduler is not supported on this system, leaving scheduler as is")
+        logger.warning("sched_getscheduler is not supported on this system, leaving scheduler as is")
     else:
         if current_sched == sched:
             # already running with RR scheduler, likely set from init system, don't touch priority


### PR DESCRIPTION
musl libc function `sched_getscheduler` always returns `ENOSYS`.
https://git.musl-libc.org/cgit/musl/tree/src/sched/sched_getscheduler.c