### PR TITLE
Fallback to smartctl if hdparm does not return model number

### DIFF
--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -184,6 +184,12 @@ class Drive(HotDevice):
             cmd, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, universal_newlines=True
         )
         model_match = self.__class__.HDPARM_GET_MODEL_REGEX.search(output)
+        if (model_match is None):
+            cmd = ("smartctl", "-i", self.device_filepath)
+            output = subprocess.check_output(
+                cmd, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, universal_newlines=True
+            )
+            model_match = self.__class__.HDPARM_GET_MODEL_REGEX.search(output)
         assert model_match is not None
         model = model_match.group(1).strip()
         return f"{os.path.basename(self.device_filepath)} {model}"

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -184,7 +184,7 @@ class Drive(HotDevice):
             cmd, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, universal_newlines=True
         )
         model_match = self.__class__.HDPARM_GET_MODEL_REGEX.search(output)
-        if (model_match is None):
+        if model_match is None:
             cmd = ("smartctl", "-i", self.device_filepath)
             output = subprocess.check_output(
                 cmd, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, universal_newlines=True

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -105,6 +105,7 @@ class Drive(HotDevice):
     HDPARM_GET_TEMP_HITACHI_ERROR_REGEX = re.compile("^SG_IO: .* sense data", re.MULTILINE)
     HDPARM_GET_MODEL_REGEX = re.compile(r"Model Number:\s*(.*)")
     HDDTEMP_SLEEPING_SUFFIX = ": drive is sleeping\n"
+    SMARTCTL_GET_MODEL_REGEX = re.compile(r"Model Number:\s*(.*)")
 
     class TempProbingMethod(enum.Enum):
 
@@ -189,7 +190,7 @@ class Drive(HotDevice):
             output = subprocess.check_output(
                 cmd, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, universal_newlines=True
             )
-            model_match = self.__class__.HDPARM_GET_MODEL_REGEX.search(output)
+            model_match = self.__class__.SMARTCTL_GET_MODEL_REGEX.search(output)
         assert model_match is not None
         model = model_match.group(1).strip()
         return f"{os.path.basename(self.device_filepath)} {model}"


### PR DESCRIPTION
`hdparm -i` on a WD SSD Black SN750 M.2 returns no output, but `smartctl -i` returns necessary information.