### PR TITLE
If the disk does not support hdparm -C, use unknown state

### DIFF
--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -266,9 +266,9 @@ class Drive(HotDevice):
                 )
                 self.get_state_count += 1
             str_state = output.rsplit(" ", 1)[-1].strip()
+            state = states[str_state]
         except Exception:
-           str_state = "unknown"
-        state = states[str_state]
+           state = self.__class__.DriveState.UNKNOWN
         self.logger.debug(f"Drive state: {state.name}")
         return state
 

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -259,12 +259,15 @@ class Drive(HotDevice):
             "sleeping": self.__class__.DriveState.SLEEPING,
         }
         cmd = ("hdparm", "-C", self.device_filepath)
-        with self.get_state_lock:
-            output = subprocess.check_output(
-                cmd, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, universal_newlines=True
-            )
-            self.get_state_count += 1
-        str_state = output.rsplit(" ", 1)[-1].strip()
+        try:
+            with self.get_state_lock:
+                output = subprocess.check_output(
+                    cmd, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, universal_newlines=True
+                )
+                self.get_state_count += 1
+            str_state = output.rsplit(" ", 1)[-1].strip()
+        except Exception:
+           str_state = "unknown"
         state = states[str_state]
         self.logger.debug(f"Drive state: {state.name}")
         return state

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -268,7 +268,7 @@ class Drive(HotDevice):
             str_state = output.rsplit(" ", 1)[-1].strip()
             state = states[str_state]
         except subprocess.CalledProcessError:
-           state = self.__class__.DriveState.UNKNOWN
+            state = self.__class__.DriveState.UNKNOWN
         self.logger.debug(f"Drive state: {state.name}")
         return state
 

--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -267,7 +267,7 @@ class Drive(HotDevice):
                 self.get_state_count += 1
             str_state = output.rsplit(" ", 1)[-1].strip()
             state = states[str_state]
-        except Exception:
+        except subprocess.CalledProcessError:
            state = self.__class__.DriveState.UNKNOWN
         self.logger.debug(f"Drive state: {state.name}")
         return state

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -194,9 +194,8 @@ SCT Commands not supported
                 universal_newlines=True,
             )
         with unittest.mock.patch("hddfancontrol.subprocess.check_output") as subprocess_check_output_mock:
-            subprocess_check_output_mock.side_effect = subprocess.CalledProcessError(0, "")
-            with self.assertRaises(Exception):
-                self.drive.getState()
+            subprocess_check_output_mock.return_value = "\n/dev/_sdz:\n drive state is:  unknown\n"
+            self.assertEqual(self.drive.getState(), hddfancontrol.Drive.DriveState.UNKNOWN)
             subprocess_check_output_mock.assert_called_once_with(
                 ("hdparm", "-C", "/dev/_sdz"),
                 stdin=subprocess.DEVNULL,
@@ -244,9 +243,8 @@ SCT Commands not supported
                 universal_newlines=True,
             )
         with unittest.mock.patch("hddfancontrol.subprocess.check_output") as subprocess_check_output_mock:
-            subprocess_check_output_mock.side_effect = subprocess.CalledProcessError(0, "")
-            with self.assertRaises(Exception):
-                self.drive.isSleeping()
+            subprocess_check_output_mock.return_value = "\n/dev/_sdz:\n drive state is:  unknown\n"
+            self.assertEqual(self.drive.getState(), hddfancontrol.Drive.DriveState.UNKNOWN)
             subprocess_check_output_mock.assert_called_once_with(
                 ("hdparm", "-C", "/dev/_sdz"),
                 stdin=subprocess.DEVNULL,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -194,7 +194,7 @@ SCT Commands not supported
                 universal_newlines=True,
             )
         with unittest.mock.patch("hddfancontrol.subprocess.check_output") as subprocess_check_output_mock:
-            subprocess_check_output_mock.return_value = "\n/dev/_sdz:\n drive state is:  unknown\n"
+            subprocess_check_output_mock.side_effect = subprocess.CalledProcessError(0, "")
             self.assertEqual(self.drive.getState(), hddfancontrol.Drive.DriveState.UNKNOWN)
             subprocess_check_output_mock.assert_called_once_with(
                 ("hdparm", "-C", "/dev/_sdz"),
@@ -243,8 +243,8 @@ SCT Commands not supported
                 universal_newlines=True,
             )
         with unittest.mock.patch("hddfancontrol.subprocess.check_output") as subprocess_check_output_mock:
-            subprocess_check_output_mock.return_value = "\n/dev/_sdz:\n drive state is:  unknown\n"
-            self.assertEqual(self.drive.getState(), hddfancontrol.Drive.DriveState.UNKNOWN)
+            subprocess_check_output_mock.side_effect = subprocess.CalledProcessError(0, "")
+            self.assertFalse(self.drive.isSleeping())
             subprocess_check_output_mock.assert_called_once_with(
                 ("hdparm", "-C", "/dev/_sdz"),
                 stdin=subprocess.DEVNULL,


### PR DESCRIPTION
`hdparm -C` on WD SSD Black SN750 M.2 returns no output.