### PR TITLE
Fix OpenRC config file path

### DIFF
--- a/openrc/hddfancontrol
+++ b/openrc/hddfancontrol
@@ -2,7 +2,7 @@
 
 description="Adjust the fan speed according to the temperature of the hard drive"
 
-cfgfile="/etc/conf.d/hddfancontrol.conf"
+cfgfile="/etc/conf.d/hddfancontrol"
 pidfile="/run/$RC_SVCNAME.pid"
 
 command=/usr/bin/hddfancontrol


### PR DESCRIPTION
Systemd service using config file without .conf extension. Same in README, OpenRC service installing commands copy config file without .conf extension. So lets fix file path in OpenRC service itself.