### PR TITLE
fix: allow scttempsts probing method for asleep drives

### DIFF
--- a/hddfancontrol/__init__.py
+++ b/hddfancontrol/__init__.py
@@ -292,6 +292,7 @@ class Drive(HotDevice):
         """Return True if drive can be probed while asleep, without waking up, False instead."""
         return self.temp_query_method in (
             Drive.TempProbingMethod.HDPARM_INVOCATION,
+            Drive.TempProbingMethod.SMARTCTL_SCT_INVOCATION,
             Drive.TempProbingMethod.DRIVETEMP,
         )
 


### PR DESCRIPTION
The smartctl scttempsts probing method works for asleep drives, without waking them up.
Stated [here](https://github.com/desbma/hddfancontrol/issues/21#issuecomment-486417599) and it matches the observations from my own experiments.

PS:
With `smartctl,5 -l devstat /dev/sda` there seems to be an additional way to query the driver temperature without waking asleep drives. This command queries the `Temperature Statistics` log page from the `Device Statistics log` (see ATA/ATAPI Command Set).
```
0x05  =====  =               =  ===  == Temperature Statistics (rev 1) ==
0x05  0x008  1              29  ---  Current Temperature
0x05  0x010  1              29  ---  Average Short Term Temperature
0x05  0x018  1               -  ---  Average Long Term Temperature
0x05  0x020  1              41  ---  Highest Temperature
0x05  0x028  1              25  ---  Lowest Temperature
0x05  0x030  1              37  ---  Highest Average Short Term Temperature
0x05  0x038  1              29  ---  Lowest Average Short Term Temperature
0x05  0x040  1               -  ---  Highest Average Long Term Temperature
0x05  0x048  1               -  ---  Lowest Average Long Term Temperature
0x05  0x050  4               0  ---  Time in Over-Temperature
0x05  0x058  1              60  ---  Specified Maximum Operating Temperature
0x05  0x060  4               0  ---  Time in Under-Temperature
0x05  0x068  1               5  ---  Specified Minimum Operating Temperature
```