### PR TITLE
Bump nix from 0.30.1 to 0.31.2 to fix s390x build failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
  "humantime",
  "itertools",
  "log",
- "nix 0.30.1",
+ "nix 0.31.2",
  "rev_lines",
  "serde",
  "serde_json",
@@ -378,18 +378,6 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ flate2 = { version = "1.1.9", default-features = false, features = ["rust_backen
 humantime = { version = "2.3.0", default-features = false }
 itertools = { version = "0.14.0", default-features = false, features = ["use_std"] }
 log = { version = "0.4.29", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
-nix = { version = "0.30.1", default-features = false, features = ["fs"] }
+nix = { version = "0.31.2", default-features = false, features = ["fs"] }
 rev_lines = { version = "0.3.0", optional = true, default-features = false }
 serde = { version = "1.0.228", default-features = false, features = ["std", "derive"], optional = true }
 serde_json = { version = "1.0.149", default-features = false, features = ["std"], optional = true }


### PR DESCRIPTION
nix 0.30.1 fails to build on s390x due to a type mismatch in `statfs` field definitions (`u32` vs `u64`). This was fixed in nix 0.31.0 via upstream PR [nix-rust/nix#2678](https://github.com/nix-rust/nix/pull/2678).

This came up while packaging hddfancontrol for Alpine Linux, where the s390x CI runner hit the build failure.

Refs: https://github.com/nix-rust/nix/issues/2683